### PR TITLE
Fixes "Floating Icons" are always enabled, ignoring argument inputs

### DIFF
--- a/host/index.html
+++ b/host/index.html
@@ -74,7 +74,7 @@
                 // ------------
 
                 // Floating icons
-                var FLOATING_ICONS = S_GET("f") || true;
+                var FLOATING_ICONS = S_GET("f");
                 // Show extra informations
                 var DEBUG_FLOATING = S_GET("dF");
 


### PR DESCRIPTION
The code are originally meant to be a default value fail-safe, but [Lua doesn't build disabled feature to the url](https://github.com/Xalalau/GMod-OG-Loading-Screen/blob/master/addon/lua/autorun/sh_ogloading.lua#L37), so the result are `(null) || true`, which causing the result become `true`.
Fixing problem on Lua doesn't really fixes the issue, as `0 || true` are `true` in JavaScript.

This will make `FLOATING_ICONS` variable can be `(null)` in JavaScript, and current code are working fine with it.